### PR TITLE
번개장터 검색 결과 광고 차단

### DIFF
--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -131,6 +131,7 @@ m.danawa.com##.box__tooltip-internet
 m.bunjang.co.kr##main > div[class^="_container_"] + section:has(> span[class*="_adTitle_"])
 m.bunjang.co.kr##div[data-grid-size] > div:has(> a[href^="https://link.coupang.com/"])
 m.bunjang.co.kr##div[data-grid-size] > div:has(> a[href^="https://ader.naver.com/"])
+m.bunjang.co.kr##div[data-grid-size] > div:has(> a[href^="/products/"][href*="&ref_source=sa&"])
 m.bunjang.co.kr##div[data-grid-size] > div:has(> a[href*="&ref_code=%22%7B%5C%22cntr%5C%22%3A%5C%22SIM3"])
 ! lottecinema.co.kr desktop
 lottecinema.co.kr##.login_ad


### PR DESCRIPTION
`ref_source=sa`로 식별되는 광고 상품 카드를 숨깁니다.
더보기 포함 120개 카드에서 대상 광고 23개 일치, 오탐·누락 0개를 확인했습니다. AGLint 통과.

Fixes #82